### PR TITLE
fixes panics on bad api responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ build-prod:
 	cd -
 copy-prod:
 	mkdir -p public/cljs-out
+	cp index.html public/index.html
 	cp -r client/target/public/cljs-out/prod* public/cljs-out
 deploy-docker-prod:
 	docker build -t ralexstokes/eth2-fork-mon .

--- a/client/src/com/github/ralexstokes/eth2_fork_mon.cljs
+++ b/client/src/com/github/ralexstokes/eth2_fork_mon.cljs
@@ -162,11 +162,13 @@
          [:tbody
           (map-indexed peer-view peers)]]]]]]))
 
-(defn head-view [network index {:keys [name slot root is-majority?]}]
+(defn head-view [network index {:keys [name eth1 slot root is-majority?]}]
   [:tr {:class (if is-majority? :table-success :table-danger)
         :key index}
    [:th {:scope :row}
     name]
+   [:th {:scope :row}
+    eth1]
    [:td [:a {:href (str "https://"
                         (network->beaconchain-prefix network)
                         "beaconcha.in/block/"
@@ -186,7 +188,8 @@
         [:table.table.table-hover
          [:thead
           [:tr
-           [:th {:scope :col} "Name"]
+           [:th {:scope :col} "Consensus"]
+           [:th {:scope :col} "Execution"]
            [:th {:scope :col} "Slot"]
            [:th {:scope :col} "Root"]]]
          [:tbody

--- a/client/src/com/github/ralexstokes/eth2_fork_mon.cljs
+++ b/client/src/com/github/ralexstokes/eth2_fork_mon.cljs
@@ -122,10 +122,12 @@
            " with root "
            [:a {:href (str "https://" network-prefix "beaconcha.in/block/" (:root finalized))} (-> finalized :root humanize-hex)]]]]]])))
 
-(defn peer-view [index {:keys [name version healthy syncing]}]
+(defn peer-view [index {:keys [name eth1 version healthy syncing]}]
   [:tr {:key index}
    [:th {:scope :row}
     name]
+   [:th {:scope :row}
+    eth1]
    [:td version]
    [:td {:style {:text-align "center"}}
     (if healthy
@@ -150,8 +152,9 @@
         [:table.table.table-hover
          [:thead
           [:tr
-           [:th {:scope :col} "Name"]
-           [:th {:scope :col} "Version"]
+           [:th {:scope :col} "Consensus"]
+           [:th {:scope :col} "Execution"]
+           [:th {:scope :col} "Eth2 Version"]
            [:th {:scope :col
                  :style {:text-align "center"}} "Healthy?"]
            [:th {:scope :col

--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content=
+            "width=device-width, initial-scale=1, shrink-to-fit=no">
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href=
+            "https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+          integrity=
+                  "sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2"
+          crossorigin="anonymous" type="text/css">
+    <link rel="stylesheet" href="style.css" type="text/css">
+
+    <title>eth2-fork-mon</title>
+</head>
+
+<body>
+<div id="root">
+    <div class="container-fluid">
+        <div class="row my-2">
+            <div class="col"></div>
+
+            <div class="col-10">
+                <h3>loading...</h3>
+            </div>
+
+            <div class="col"></div>
+        </div>
+    </div>
+</div><script src=
+                      "https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity=
+                      "sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+              crossorigin="anonymous" type="text/javascript">
+</script><script src=
+                         "https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+                 integrity=
+                         "sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+                 crossorigin="anonymous" type="text/javascript">
+</script><script src="/cljs-out/prod-main.js" type=
+        "text/javascript">
+</script>
+</body>
+</html>

--- a/pkg/monitor/config.go
+++ b/pkg/monitor/config.go
@@ -7,8 +7,13 @@ type Eth2Config struct {
 	Network        string `json:"network" yaml:"network"`
 }
 
+type Endpoint struct {
+	Addr string `json:"addr" yaml:"addr"`
+	Eth1 string `json:"eth1" yaml:"eth1"`
+}
+
 type Config struct {
-	Endpoints           []string
+	Endpoints           []Endpoint
 	Eth2                Eth2Config
 	OutputDir           string
 	EtherscanAPIKey     string `yaml:"etherscan_api_key"`

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -178,6 +178,7 @@ func (m *Monitor) sendSpec(w http.ResponseWriter, r *http.Request) {
 
 type nodeResp struct {
 	ID      string `json:"id"`
+	Eth1    string `json:"eth1"`
 	Version string `json:"version"`
 	Slot    string `json:"slot"`
 	Root    string `json:"root"`
@@ -196,6 +197,7 @@ func (m *Monitor) sendMonitorState(w http.ResponseWriter, r *http.Request) {
 	for _, node := range m.nodes {
 		response := nodeResp{
 			ID:      node.id,
+			Eth1:    node.eth1,
 			Version: node.version,
 			Slot:    node.latestHead.slot,
 			Root:    node.latestHead.root,
@@ -579,7 +581,7 @@ func FromConfig(config *Config) *Monitor {
 	var forkChoiceProvider *Node
 	var participationProvider *Node
 	for _, endpoint := range config.Endpoints {
-		node, err := nodeAtEndpoint(endpoint, time.Duration(config.MillisecondsTimeout))
+		node, err := nodeAtEndpoint(endpoint.Addr, endpoint.Eth1, time.Duration(config.MillisecondsTimeout))
 		if err != nil {
 			log.Println(err)
 			continue

--- a/pkg/monitor/node.go
+++ b/pkg/monitor/node.go
@@ -42,8 +42,8 @@ func idHashOf(peerID string) string {
 	return hex.EncodeToString(digest)[:8]
 }
 
-func nodeAtEndpoint(endpoint string, msHTTPTimeout time.Duration) (*Node, error) {
-	n := &Node{endpoint: endpoint}
+func nodeAtEndpoint(endpoint string, eth1 string, msHTTPTimeout time.Duration) (*Node, error) {
+	n := &Node{endpoint: endpoint, eth1: eth1}
 
 	// set timeout for all HTTP requests...
 	// in particular, Prysm endpoint can be slow...
@@ -178,6 +178,7 @@ func (n *Node) doFetchSyncStatus() error {
 
 type Node struct {
 	id       string
+	eth1     string
 	endpoint string
 	version  string
 
@@ -189,7 +190,7 @@ type Node struct {
 }
 
 func (n *Node) String() string {
-	return fmt.Sprintf("[healthy: %t] %s at %s has head %s", n.isHealthy, n.version, n.endpoint, n.latestHead)
+	return fmt.Sprintf("[healthy: %t] %s - %s at %s has head %s", n.isHealthy, n.eth1, n.version, n.endpoint, n.latestHead)
 }
 
 func isPrysm(identifier string) bool {

--- a/pkg/monitor/node.go
+++ b/pkg/monitor/node.go
@@ -160,7 +160,8 @@ func (n *Node) doFetchSyncStatus() error {
 	}
 	inner, ok := syncData["data"].(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("no data")
+		// error message, likely pre-genesis., just don't change the last status.
+		return nil
 	}
 	if result, ok := inner["is_syncing"].(bool); ok {
 		n.isSyncing = result

--- a/pkg/monitor/node.go
+++ b/pkg/monitor/node.go
@@ -67,7 +67,10 @@ func nodeAtEndpoint(endpoint string, msHTTPTimeout time.Duration) (*Node, error)
 		if err != nil {
 			return nil, err
 		}
-		version := versionData["version"].(string)
+		version, ok := versionData["version"].(string)
+		if !ok {
+			return nil, fmt.Errorf("bad version string")
+		}
 		n.version = version
 
 		n.id = idHashOf(endpoint)


### PR DESCRIPTION
The monitor would panic on a lot of api interactions with the mergenet nodes. This keeps the node running (still figuring out what the bad api responses are about).

Also, I copied the index.html from the live site and put it into my docker image to have a host-page. The clojure frontend thing only built js files for me, not the host page. Is this intentional? Do you host it in nginx or somewhere else? I've the go file server just serve it, works fine.